### PR TITLE
chore(inventory): remove retired Windows host

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is my homelab config. The repo is called `pi` because it started as a singl
 - `ailab-ubuntu` (192.168.50.10) — bare-metal GPU server: dual RTX 3090 (LLM inference, STT, embeddings, Immich ML) + RTX 5060 Ti eGPU (ComfyUI, Wan2GP, Wolf)
 - `ubuntu-8gb-fsn1-1` / Hetzner (Tailnet IP 100.82.91.51) — cloud Docker host for Hermes agents
 - `dashserv-m-1` (77.90.42.61) — public VPS baseline host
-- `clawd` (192.168.50.12) and `winhost1` (192.168.50.11) — additional managed/special-purpose hosts
+- `clawd` (192.168.50.12) — additional managed/special-purpose host
 
 ## Bootstrap the Pi
 

--- a/distribute_ssh_key.yml
+++ b/distribute_ssh_key.yml
@@ -18,7 +18,7 @@
         ssh_public_key: "{{ ssh_public_key_b64['content'] | b64decode }}"
 
 - name: Add SSH public key to all hosts
-  hosts: all:!winhost1
+  hosts: all
   become: yes
   gather_facts: yes
 

--- a/docs/ops-user-migration.md
+++ b/docs/ops-user-migration.md
@@ -282,8 +282,8 @@ Wenn etwas fehlschlägt:
   verschleiert sonst den Akteur in Audit-Logs. Key-Fingerprints sind die primäre Zuordnung.
 - **Revocation ist Pflicht:** `ops`-Keys dürfen nicht nur mit `exclusive: false` anwachsen. Für
   `ops` managed/exclusive Keylisten oder explizites Pruning verwenden.
-- **Inventory-Platzhalter/Plaintext prüfen:** `inventory` enthält `winhost1 … ansible_password=…`
-  im Klartext → Vault. Nicht ops-spezifisch, aber sicherheitsrelevant.
+- **Inventory und Git-Historie auf Klartext-Secrets prüfen:** Zugangsdaten gehören in den Vault,
+  nicht ins Inventory. Nicht ops-spezifisch, aber sicherheitsrelevant.
 - **Root-/Daniel-Zugang** erst einschränken, **nachdem** `ops` auf dem Host verifiziert funktioniert
   und ein Recovery-Pfad bestätigt ist.
 - **`cloud_security_ssh_allow_users` beachten:** falls gesetzt, muss `ops` enthalten sein, sonst

--- a/inventory
+++ b/inventory
@@ -7,9 +7,6 @@ homelab-nuc ansible_host=192.168.50.5 ansible_user=root ansible_python_interpret
 [ailab_ubuntus]
 ailab-ubuntu ansible_host=192.168.50.10 ansible_user=daniel ansible_python_interpreter=/usr/bin/python3
 
-[ailab_windows]
-winhost1 ansible_host=192.168.50.11 ansible_user=AdminUser ansible_password=SecretPassword ansible_connection=winrm ansible_winrm_server_cert_validation=ignore
-
 [clawds]
 clawd ansible_host=192.168.50.12 ansible_user=daniel ansible_python_interpreter=/usr/bin/python3
 


### PR DESCRIPTION
## Summary
- remove the retired `winhost1` WinRM inventory group
- remove stale documentation and SSH-key-playbook references
- generalize the inventory security note to cover plaintext secrets and Git history

## Validation
- `uv run yamllint distribute_ssh_key.yml`
- `git diff --check`
- verified no remaining `winhost1` or `ailab_windows` references

> Full repository `yamllint .` and Ansible syntax validation remain blocked by pre-existing lint findings and the unavailable local `.vault_pass`, respectively.
